### PR TITLE
add optional skylight requirement and allow 0 chance config

### DIFF
--- a/src/main/java/crispytwig/heftycrops/HeftyCrops.java
+++ b/src/main/java/crispytwig/heftycrops/HeftyCrops.java
@@ -53,9 +53,13 @@ public class HeftyCrops {
 
     @SubscribeEvent
     public void onCropGrow(BlockEvent.CropGrowEvent.Post event) {
+        if(Config.HEFTY_CROP_WEIGHT.get() == 0) return;
+
         BlockPos pos = event.getPos();
         LevelAccessor level = event.getWorld();
         BlockState postState = event.getState();
+
+        if(Config.HEFTY_CROP_REQUIRES_UNOBSTRUCTED_SKYVIEW.get() && !level.canSeeSky(pos)) return;
 
 
         // Vanilla Crop Blocks

--- a/src/main/java/crispytwig/heftycrops/registry/Config.java
+++ b/src/main/java/crispytwig/heftycrops/registry/Config.java
@@ -9,11 +9,13 @@ import net.minecraftforge.fml.event.config.ModConfigEvent;
 @Mod.EventBusSubscriber(modid = HeftyCrops.MOD_ID)
 public class Config {
     public static final ForgeConfigSpec.IntValue HEFTY_CROP_WEIGHT;
+    public static final ForgeConfigSpec.BooleanValue HEFTY_CROP_REQUIRES_UNOBSTRUCTED_SKYVIEW;
     public static ForgeConfigSpec COMMON_CONFIG;
 
     static {
         ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
-        HEFTY_CROP_WEIGHT = COMMON_BUILDER.comment("Chance of hefty crop spawning. Larger number = rarer. A value of 1 will guarantee a hefty crop spawns.").defineInRange("weight", 25, 1, 100);
+        HEFTY_CROP_WEIGHT = COMMON_BUILDER.comment("Chance of hefty crop spawning. Larger number = rarer. A value of 1 will guarantee a hefty crop spawns. A value of 0 will disable hefty crop spawns.").defineInRange("weight", 25, 0, 100);
+        HEFTY_CROP_REQUIRES_UNOBSTRUCTED_SKYVIEW = COMMON_BUILDER.comment("If true, hefty crops may only spawn if the sky is visible (F3 Sky Light Level == 15)").define("requiresUnobstructedSkyView", false);
         Config.COMMON_CONFIG = COMMON_BUILDER.build();
     }
 


### PR DESCRIPTION
Greetings! Thank you for this small but genious mod.

There are a lot of automation mods that will trip up when a hefty crop spawns. This PR adds 2 simple changes, both are done in a way that keep the original behavior as the default.

## 1. Allow 0 weight config for spawns
Previously, the weight was limited to a value between 1 and 100. I've extended the range to include 0 and added a check for 0 in the `onCropGrow` event handler.  The default of 25 is unchanged. This option is targeted towards modpacks which only want to use the hefty crops as decorative objects. It would be up to them to add options to obtain the hefty crops when disabling the spawning.

## 2. Add sky light requirement
As requested in issue #2, I've added a configuration option that allows hefty crops to only spawn under direct sky light (sky light level == 15). This still allows crops to grow under glas since glas does not change the skylight level, but anything that reduces the skylight level for a given location, would prevent hefty crops to grow. The default value is set to `false`.

